### PR TITLE
Deliver posts to other accounts mentioned in a post

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ LDFLAGS=-s -w
 
 cli:
 	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/server cmd/server/main.go
+	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/add-account cmd/add-account/main.go
+	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/create-post cmd/create-post/main.go
 	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/list-followers cmd/list-followers/main.go
 	go build -mod $(GOMOD) -ldflags="$(LDFLAGS)" -o bin/list-addresses cmd/list-addresses/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,12 @@ accounts:
 	go run cmd/add-account/main.go \
 		-accounts-database-uri '$(ACCOUNTS_DB_URI)' \
 		-aliases-database-uri '$(ALIASES_DB_URI)' \
+		-account-name doug \
+		-alias doug \
+		-account-type Service
+	go run cmd/add-account/main.go \
+		-accounts-database-uri '$(ACCOUNTS_DB_URI)' \
+		-aliases-database-uri '$(ALIASES_DB_URI)' \
 		-account-name alice \
 		-account-type Person \
 		-account-icon-uri 's3blob://sfomuseum-media/ap/icons/sfo.jpg?region=us-west-2&credentials=session'
@@ -156,6 +162,8 @@ post:
 		-insecure \
 		-verbose
 
+# -mention $(MENTION) \
+
 reply:
 	go run cmd/create-post/main.go \
 		-accounts-database-uri '$(ACCOUNTS_DB_URI)' \
@@ -166,7 +174,6 @@ reply:
 		-account-name bob \
 		-message "$(MESSAGE)" \
 		-in-reply-to $(INREPLYTO) \
-		-mention $(MENTION) \
 		-hostname localhost:8080 \
 		-insecure \
 		-verbose

--- a/address.go
+++ b/address.go
@@ -15,7 +15,7 @@ import (
 
 // this is an updated of the above with support for @localhost addresses
 
-const pat_rfc5322 string = "(?i)@(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(localhost|(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\]))"
+const pat_rfc5322 string = "(?i)@(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(localhost(?:\\:\\d+)?|(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\]))"
 
 // To do: update to use pat_rfc5322
 
@@ -53,6 +53,8 @@ func ParseAddressesFromString(body string) ([]string, error) {
 	lookup := make(map[string]bool)
 
 	for _, m := range matches {
+
+		slog.Info("WTF", "match", m)
 		lookup[m[0]] = true
 	}
 
@@ -61,6 +63,6 @@ func ParseAddressesFromString(body string) ([]string, error) {
 	for k, _ := range lookup {
 		addresses = append(addresses, k)
 	}
-	
+
 	return addresses, nil
 }

--- a/address.go
+++ b/address.go
@@ -11,7 +11,11 @@ import (
 // which in turn was copied from: https://stackoverflow.com/a/201378/5405453
 // updated to add leading '@'
 
-const pat_rfc5322 string = "(?i)@(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
+// const pat_rfc5322 string = "(?i)@(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])"
+
+// this is an updated of the above with support for @localhost addresses
+
+const pat_rfc5322 string = "(?i)@(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(localhost|(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\]))"
 
 // To do: update to use pat_rfc5322
 
@@ -46,11 +50,17 @@ func ParseAddressFromRequest(req *http.Request) (string, string, error) {
 func ParseAddressesFromString(body string) ([]string, error) {
 
 	matches := re_addresses.FindAllStringSubmatch(body, -1)
-	addresses := make([]string, len(matches))
+	lookup := make(map[string]bool)
 
-	for idx, m := range matches {
-		addresses[idx] = m[0]
+	for _, m := range matches {
+		lookup[m[0]] = true
 	}
 
+	addresses := make([]string, 0)
+
+	for k, _ := range lookup {
+		addresses = append(addresses, k)
+	}
+	
 	return addresses, nil
 }

--- a/address_test.go
+++ b/address_test.go
@@ -85,6 +85,9 @@ func TestParseAddressesFromString(t *testing.T) {
 		"hello @bob@example.com pass the mustard to @alice@mustard.com and doug@localhost":                                                   2,
 		"hello @bob@example.com pass the mustard to @alice@mustard.com and doug@localhost before sending it @doug@bob.com":                   3,
 		"hello @bob@example.com pass the mustard to @alice@mustard.com and doug@localhost before sending it @doug@bob.com and max@gmail.com": 3,
+		"test mentioning @doug@localhost yo": 1,
+		"test mentioning @doug@localhost:8080 and @bob@localhost:8080 yo": 2,
+		"test mentioning @doug@localhost:8080 and @bob@localhost:8080 yo @alice@alice.com": 3,				
 	}
 
 	for str, expected_count := range tests {

--- a/address_test.go
+++ b/address_test.go
@@ -8,12 +8,14 @@ import (
 func TestParseAddressFromRequest(t *testing.T) {
 
 	tests := map[string][2]string{
-		"bob":                [2]string{"bob", ""},
-		"@bob":               [2]string{"bob", ""},
-		"@bob@localhost":     [2]string{"bob", "localhost"},
-		"@bob@bob.com":       [2]string{"bob", "bob.com"},
-		"acct:@bob@bob.com":  [2]string{"bob", "bob.com"},
-		"acct:alice@bob.com": [2]string{"alice", "bob.com"},
+		"bob":                  [2]string{"bob", ""},
+		"@bob":                 [2]string{"bob", ""},
+		"@bob@localhost":       [2]string{"bob", "localhost"},
+		"@bob@bob.com":         [2]string{"bob", "bob.com"},
+		"acct:@bob@bob.com":    [2]string{"bob", "bob.com"},
+		"acct:alice@bob.com":   [2]string{"alice", "bob.com"},
+		"@bob@localhost:8080":  [2]string{"bob", "localhost:8080"},
+		"@doug@localhost:8080": [2]string{"doug", "localhost:8080"},
 	}
 
 	for addr, expected := range tests {
@@ -85,9 +87,9 @@ func TestParseAddressesFromString(t *testing.T) {
 		"hello @bob@example.com pass the mustard to @alice@mustard.com and doug@localhost":                                                   2,
 		"hello @bob@example.com pass the mustard to @alice@mustard.com and doug@localhost before sending it @doug@bob.com":                   3,
 		"hello @bob@example.com pass the mustard to @alice@mustard.com and doug@localhost before sending it @doug@bob.com and max@gmail.com": 3,
-		"test mentioning @doug@localhost yo": 1,
-		"test mentioning @doug@localhost:8080 and @bob@localhost:8080 yo": 2,
-		"test mentioning @doug@localhost:8080 and @bob@localhost:8080 yo @alice@alice.com": 3,				
+		"test mentioning @doug@localhost yo":                                               1,
+		"test mentioning @doug@localhost:8080 and @bob@localhost:8080 yo":                  2,
+		"test mentioning @doug@localhost:8080 and @bob@localhost:8080 yo @alice@alice.com": 3,
 	}
 
 	for str, expected_count := range tests {

--- a/app/post/create/create.go
+++ b/app/post/create/create.go
@@ -113,6 +113,10 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *slog.Logger) 
 		p.InReplyTo = opts.InReplyTo
 	}
 
+	// START OF put me in a function
+	// Something like: post_tags, err := activitypub.AddPost(ctx, posts_db, posts_tags_db, p)
+	// which is not a great interface... 
+	
 	err = posts_db.AddPost(ctx, p)
 
 	if err != nil {
@@ -121,10 +125,18 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *slog.Logger) 
 
 	// Something something something extract mentions from opts.Message too...
 
+	addrs_mentioned, err := activitypub.ParseAddressesFromString(opts.Message)
+
+	if err != nil {
+		return fmt.Errorf("Failed to derive addresses mentioned in message body, %w", err)
+	}
+	
 	post_tags := make([]*activitypub.PostTag, 0)
 
-	for _, name := range opts.Mentions {
-
+	// for _, name := range opts.Mentions {
+	
+	for _, name := range addrs_mentioned {
+		
 		actor, err := activitypub.RetrieveActor(ctx, name, opts.URIs.Insecure)
 
 		if err != nil {

--- a/app/post/create/create.go
+++ b/app/post/create/create.go
@@ -115,6 +115,8 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *slog.Logger) 
 		return fmt.Errorf("Failed to add post, %w", err)
 	}
 
+	logger.Info("YO", "post", post.Id, "tags", post_tags)
+	
 	if opts.InReplyTo != "" {
 		post.InReplyTo = opts.InReplyTo
 	}

--- a/app/post/create/create.go
+++ b/app/post/create/create.go
@@ -116,7 +116,7 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *slog.Logger) 
 	}
 
 	logger.Info("YO", "post", post.Id, "tags", post_tags)
-	
+
 	if opts.InReplyTo != "" {
 		post.InReplyTo = opts.InReplyTo
 	}

--- a/app/post/create/create.go
+++ b/app/post/create/create.go
@@ -115,68 +115,9 @@ func RunWithOptions(ctx context.Context, opts *RunOptions, logger *slog.Logger) 
 		return fmt.Errorf("Failed to add post, %w", err)
 	}
 
-	logger.Info("YO", "post", post.Id, "tags", post_tags)
-
 	if opts.InReplyTo != "" {
 		post.InReplyTo = opts.InReplyTo
 	}
-
-	/*
-		p, err := activitypub.NewPost(ctx, acct, opts.Message)
-
-		if err != nil {
-			return fmt.Errorf("Failed to create new post, %w", err)
-		}
-
-		if opts.InReplyTo != "" {
-			p.InReplyTo = opts.InReplyTo
-		}
-
-		err = posts_db.AddPost(ctx, p)
-
-		if err != nil {
-			return fmt.Errorf("Failed to add post, %w", err)
-		}
-
-		addrs_mentioned, err := activitypub.ParseAddressesFromString(opts.Message)
-
-		if err != nil {
-			return fmt.Errorf("Failed to derive addresses mentioned in message body, %w", err)
-		}
-
-		post_tags := make([]*activitypub.PostTag, 0)
-
-		// for _, name := range opts.Mentions {
-
-		for _, name := range addrs_mentioned {
-
-			actor, err := activitypub.RetrieveActor(ctx, name, opts.URIs.Insecure)
-
-			if err != nil {
-				slog.Error("Failed to retrieve actor data for name, skipping", "name", name, "error", err)
-				continue
-			}
-
-			href := actor.Id
-
-			t, err := activitypub.NewMention(ctx, p, name, href)
-
-			if err != nil {
-				return fmt.Errorf("Failed to create mention for '%s', %w", name, err)
-			}
-
-			err = post_tags_db.AddPostTag(ctx, t)
-
-			if err != nil {
-				return fmt.Errorf("Failed to record post tag (mention) for '%s', %w", name, err)
-			}
-
-			post_tags = append(post_tags, t)
-		}
-
-		// END OF put me in a function
-
-	*/
 
 	deliver_opts := &activitypub.DeliverPostToFollowersOptions{
 		AccountsDatabase:   accounts_db,

--- a/app/post/create/flags.go
+++ b/app/post/create/flags.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 
 	"github.com/sfomuseum/go-flags/flagset"
-	"github.com/sfomuseum/go-flags/multi"
 )
 
 var accounts_database_uri string
@@ -20,9 +19,6 @@ var message string
 var in_reply_to string
 
 var max_attempts int
-
-// Deprecated
-var mentions multi.MultiString
 
 var hostname string
 var insecure bool
@@ -47,9 +43,6 @@ func DefaultFlagSet() *flag.FlagSet {
 	fs.IntVar(&max_attempts, "max-attempts", 5, "...")
 	fs.StringVar(&message, "message", "", "...")
 	fs.StringVar(&in_reply_to, "in-reply-to", "", "...")
-
-	// Deprecated
-	fs.Var(&mentions, "mention", "...")
 
 	fs.BoolVar(&verbose, "verbose", false, "Enable verbose logging")
 	return fs

--- a/app/post/create/flags.go
+++ b/app/post/create/flags.go
@@ -21,6 +21,7 @@ var in_reply_to string
 
 var max_attempts int
 
+// Deprecated
 var mentions multi.MultiString
 
 var hostname string
@@ -46,6 +47,8 @@ func DefaultFlagSet() *flag.FlagSet {
 	fs.IntVar(&max_attempts, "max-attempts", 5, "...")
 	fs.StringVar(&message, "message", "", "...")
 	fs.StringVar(&in_reply_to, "in-reply-to", "", "...")
+
+	// Deprecated
 	fs.Var(&mentions, "mention", "...")
 
 	fs.BoolVar(&verbose, "verbose", false, "Enable verbose logging")

--- a/app/post/create/options.go
+++ b/app/post/create/options.go
@@ -20,6 +20,7 @@ type RunOptions struct {
 	Message               string
 	InReplyTo             string
 	MaxAttempts           int
+	// Deprecated
 	Mentions              []string
 	URIs                  *uris.URIs
 	Verbose               bool
@@ -49,6 +50,7 @@ func OptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, err
 		AccountName:           account_name,
 		Message:               message,
 		InReplyTo:             in_reply_to,
+		// Deprecated
 		Mentions:              mentions,
 		URIs:                  uris_table,
 		Verbose:               verbose,

--- a/app/post/create/options.go
+++ b/app/post/create/options.go
@@ -21,9 +21,9 @@ type RunOptions struct {
 	InReplyTo             string
 	MaxAttempts           int
 	// Deprecated
-	Mentions              []string
-	URIs                  *uris.URIs
-	Verbose               bool
+	Mentions []string
+	URIs     *uris.URIs
+	Verbose  bool
 }
 
 func OptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, error) {
@@ -51,10 +51,10 @@ func OptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, err
 		Message:               message,
 		InReplyTo:             in_reply_to,
 		// Deprecated
-		Mentions:              mentions,
-		URIs:                  uris_table,
-		Verbose:               verbose,
-		MaxAttempts:           max_attempts,
+		Mentions:    mentions,
+		URIs:        uris_table,
+		Verbose:     verbose,
+		MaxAttempts: max_attempts,
 	}
 
 	return opts, nil

--- a/app/post/create/options.go
+++ b/app/post/create/options.go
@@ -20,10 +20,8 @@ type RunOptions struct {
 	Message               string
 	InReplyTo             string
 	MaxAttempts           int
-	// Deprecated
-	Mentions []string
-	URIs     *uris.URIs
-	Verbose  bool
+	URIs                  *uris.URIs
+	Verbose               bool
 }
 
 func OptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, error) {
@@ -50,11 +48,9 @@ func OptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, err
 		AccountName:           account_name,
 		Message:               message,
 		InReplyTo:             in_reply_to,
-		// Deprecated
-		Mentions:    mentions,
-		URIs:        uris_table,
-		Verbose:     verbose,
-		MaxAttempts: max_attempts,
+		URIs:                  uris_table,
+		Verbose:               verbose,
+		MaxAttempts:           max_attempts,
 	}
 
 	return opts, nil

--- a/app/server/flags.go
+++ b/app/server/flags.go
@@ -26,6 +26,9 @@ var allow_create bool
 var allow_likes bool
 var allow_boosts bool
 
+// Allows posts to accounts not followed by author but where account is mentioned in post
+var allow_mentions bool
+
 var allow_remote_icon_uri bool
 
 var verbose bool
@@ -50,6 +53,7 @@ func DefaultFlagSet() *flag.FlagSet {
 	fs.BoolVar(&allow_create, "allow-create", false, "...")
 	fs.BoolVar(&allow_likes, "allow-likes", true, "...")
 	fs.BoolVar(&allow_boosts, "allow-boosts", true, "...")
+	fs.BoolVar(&allow_mentions, "allow-mentions", true, "...")
 
 	fs.StringVar(&server_uri, "server-uri", "http://localhost:8080", "...")
 	fs.StringVar(&hostname, "hostname", "", "...")

--- a/app/server/handlers_actvitypub.go
+++ b/app/server/handlers_actvitypub.go
@@ -122,6 +122,7 @@ func inboxPostHandlerFunc(ctx context.Context) (http.Handler, error) {
 		AllowCreate:       run_opts.AllowCreate,
 		AllowLikes:        run_opts.AllowLikes,
 		AllowBoosts:       run_opts.AllowBoosts,
+		AllowMentions:     run_opts.AllowMentions,
 	}
 
 	return www.InboxPostHandler(opts)

--- a/app/server/options.go
+++ b/app/server/options.go
@@ -23,22 +23,24 @@ type MiddlewareFunc func(http.Handler) http.Handler
 type CustomHandlersFunc func(*http.ServeMux) error
 
 type RunOptions struct {
-	ServerURI                string
-	URIs                     *uris.URIs
-	AccountsDatabaseURI      string
-	AliasesDatabaseURI       string
-	FollowersDatabaseURI     string
-	FollowingDatabaseURI     string
-	NotesDatabaseURI         string
-	MessagesDatabaseURI      string
-	BlocksDatabaseURI        string
-	PostsDatabaseURI         string
-	LikesDatabaseURI         string
-	BoostsDatabaseURI        string
-	AllowFollow              bool
-	AllowCreate              bool
-	AllowLikes               bool
-	AllowBoosts              bool
+	ServerURI            string
+	URIs                 *uris.URIs
+	AccountsDatabaseURI  string
+	AliasesDatabaseURI   string
+	FollowersDatabaseURI string
+	FollowingDatabaseURI string
+	NotesDatabaseURI     string
+	MessagesDatabaseURI  string
+	BlocksDatabaseURI    string
+	PostsDatabaseURI     string
+	LikesDatabaseURI     string
+	BoostsDatabaseURI    string
+	AllowFollow          bool
+	AllowCreate          bool
+	AllowLikes           bool
+	AllowBoosts          bool
+	// Allows posts to accounts not followed by author but where account is mentioned in post
+	AllowMentions            bool
 	AllowRemoteIconURI       bool
 	Verbose                  bool
 	Templates                *template.Template
@@ -94,6 +96,7 @@ func OptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, err
 		AllowFollow:          allow_follow,
 		AllowCreate:          allow_create,
 		AllowBoosts:          allow_boosts,
+		AllowMentions:        allow_mentions,
 		AllowLikes:           allow_likes,
 		AllowRemoteIconURI:   allow_remote_icon_uri,
 		Verbose:              verbose,

--- a/cmd/list-addresses/main.go
+++ b/cmd/list-addresses/main.go
@@ -10,13 +10,13 @@ $> echo "hello @bob@example.com pass the mustard to @alice@mustard.com and doug@
 */
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"log"
-	"strings"
-	"bufio"
 	"os"
-	
+	"strings"
+
 	"github.com/sfomuseum/go-activitypub"
 )
 
@@ -30,7 +30,7 @@ func main() {
 
 		body = ""
 		scanner := bufio.NewScanner(os.Stdin)
-		
+
 		for scanner.Scan() {
 			line := scanner.Text()
 			body = fmt.Sprintf("%s %s", body, line)
@@ -42,7 +42,7 @@ func main() {
 			log.Fatalf("Failed to read data, %v", err)
 		}
 	}
-	
+
 	addrs, err := activitypub.ParseAddressesFromString(body)
 
 	if err != nil {

--- a/post.go
+++ b/post.go
@@ -27,6 +27,75 @@ type Post struct {
 	LastModified int64  `json:"lastmodified"`
 }
 
+type AddPostOptions struct {
+	URIs             *uris.URIs
+	PostsDatabase    PostsDatabase
+	PostTagsDatabase PostTagsDatabase
+}
+
+// AddPost...
+func AddPost(ctx context.Context, opts *AddPostOptions, acct *Account, body string) (*Post, []*PostTag, error) {
+
+	// Create the new post record
+	
+	p, err := NewPost(ctx, acct, body)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to create new post, %w", err)
+	}
+
+	// Add the post to the database
+	
+	err = opts.PostsDatabase.AddPost(ctx, p)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to add post, %w", err)
+	}
+
+	// Determine other accounts mentioned in post
+	
+	addrs_mentioned, err := ParseAddressesFromString(body)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to derive addresses mentioned in message body, %w", err)
+	}
+
+	// Create "mention" tags for any other accounts mentioned in post
+	// Add each mention to the "post tags" database
+	
+	post_tags := make([]*PostTag, 0)
+
+	for _, name := range addrs_mentioned {
+
+		actor, err := RetrieveActor(ctx, name, opts.URIs.Insecure)
+
+		if err != nil {
+			slog.Error("Failed to retrieve actor data for name, skipping", "name", name, "error", err)
+			continue
+		}
+
+		href := actor.Id
+
+		t, err := NewMention(ctx, p, name, href)
+
+		if err != nil {
+			return nil, nil, fmt.Errorf("Failed to create mention for '%s', %w", name, err)
+		}
+
+		err = opts.PostTagsDatabase.AddPostTag(ctx, t)
+
+		if err != nil {
+			return nil, nil, fmt.Errorf("Failed to record post tag (mention) for '%s', %w", name, err)
+		}
+
+		post_tags = append(post_tags, t)
+	}
+
+	// Return all the things
+	
+	return p, post_tags, nil
+}
+
 func NewPost(ctx context.Context, acct *Account, body string) (*Post, error) {
 
 	post_id, err := id.NewId()

--- a/post.go
+++ b/post.go
@@ -33,7 +33,9 @@ type AddPostOptions struct {
 	PostTagsDatabase PostTagsDatabase
 }
 
-// AddPost...
+// AddPost creates a new post record for 'body' and adds it to the post database. Then it parses 'body' looking
+// for other ActivityPub addresses and records each as a "mention" in the post tags database. It returns the post
+// and the list of post tags (mentions) for further processing as needed.
 func AddPost(ctx context.Context, opts *AddPostOptions, acct *Account, body string) (*Post, []*PostTag, error) {
 
 	// Create the new post record

--- a/post.go
+++ b/post.go
@@ -39,7 +39,7 @@ type AddPostOptions struct {
 func AddPost(ctx context.Context, opts *AddPostOptions, acct *Account, body string) (*Post, []*PostTag, error) {
 
 	// Create the new post record
-	
+
 	p, err := NewPost(ctx, acct, body)
 
 	if err != nil {
@@ -47,7 +47,7 @@ func AddPost(ctx context.Context, opts *AddPostOptions, acct *Account, body stri
 	}
 
 	// Add the post to the database
-	
+
 	err = opts.PostsDatabase.AddPost(ctx, p)
 
 	if err != nil {
@@ -55,7 +55,7 @@ func AddPost(ctx context.Context, opts *AddPostOptions, acct *Account, body stri
 	}
 
 	// Determine other accounts mentioned in post
-	
+
 	addrs_mentioned, err := ParseAddressesFromString(body)
 
 	if err != nil {
@@ -64,10 +64,12 @@ func AddPost(ctx context.Context, opts *AddPostOptions, acct *Account, body stri
 
 	// Create "mention" tags for any other accounts mentioned in post
 	// Add each mention to the "post tags" database
-	
+
 	post_tags := make([]*PostTag, 0)
 
 	for _, name := range addrs_mentioned {
+
+		slog.Info("RETRIEVE", "name", name)
 
 		actor, err := RetrieveActor(ctx, name, opts.URIs.Insecure)
 
@@ -94,7 +96,7 @@ func AddPost(ctx context.Context, opts *AddPostOptions, acct *Account, body stri
 	}
 
 	// Return all the things
-	
+
 	return p, post_tags, nil
 }
 


### PR DESCRIPTION
* Add `activitypub.AddPost` method to wrap creating posts and mentions (post tags) in a single method
* Update `app/post/create` to use `activitypub.AddPost` method
* Update `www.InboxPostHandler` to accept posts from not already followed if the target account is mentioned (can be disabled by setting `InboxPostHandlerOptions.AllowMentions` to false.
* Add `activitypub.ParseAddressesFromString` method to extract ActivityPub addresses from text
* Update vendor deps